### PR TITLE
feat(ui): add OM favicon and dark-mode mobile tab color

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       className="dark"
       style={{ colorScheme: "dark" }} // ensures server/client match
     >
+      <head>
+        {/* Favicon */}
+        <link rel="icon" href="/favicon.svg" />
+        {/* Optional: set tab color for mobile browsers */}
+        <meta name="theme-color" content="#000319" />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Omar El Manssouri">
+  <title>OM — Omar El Manssouri</title>
+  <rect width="64" height="64" rx="12" fill="transparent"/>
+  <circle cx="32" cy="32" r="26" fill="#000" />
+  <text x="32" y="32" text-anchor="middle" dominant-baseline="middle"
+        font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Arial"
+        font-weight="700" font-size="20" fill="#CBACF9">OM</text>
+</svg>


### PR DESCRIPTION
## Summary
This pull request introduces a branded favicon and improves the dark-mode experience on mobile browsers.

## Changes
- **Favicon:** Added `/public/favicon.svg` — a simple OM monogram (purple on black badge) for clear branding.
- **Layout:** Updated `app/layout.tsx` to include:

  ```html
  <link rel="icon" href="/favicon.svg" />
  <meta name="theme-color" content="#000319" /> ```
  

## Testing
- Open the site in a desktop browser: favicon should display in the tab.
- On a mobile browser (Chrome/Android): tab/address bar should adopt the #000319 dark shade.